### PR TITLE
Misc fixes

### DIFF
--- a/ROMSIMMFlasher.pro
+++ b/ROMSIMMFlasher.pro
@@ -11,11 +11,13 @@ TEMPLATE = app
 QMAKE_TARGET_BUNDLE_PREFIX = com.downtowndougbrown
 
 SOURCES += main.cpp\
+    droppablegroupbox.cpp \
         mainwindow.cpp \
     programmer.cpp \
     aboutbox.cpp
 
 HEADERS  += mainwindow.h \
+    droppablegroupbox.h \
     programmer.h \
     aboutbox.h
 

--- a/ROMSIMMFlasher.pro
+++ b/ROMSIMMFlasher.pro
@@ -45,7 +45,7 @@ lessThan(QT_MAJOR_VERSION, 5) {
 	win32:RC_ICONS = SIMMProgrammer.ico
 }
 
-VERSION = 1.1.2
+VERSION = 1.2.0
 DEFINES += VERSION_STRING=\\\"$$VERSION\\\"
 
 macx:QMAKE_INFO_PLIST = Info.plist

--- a/aboutbox.h
+++ b/aboutbox.h
@@ -29,7 +29,7 @@ class AboutBox;
 class AboutBox : public QDialog
 {
     Q_OBJECT
-    
+
 public:
     static AboutBox *instance();
 private slots:

--- a/droppablegroupbox.cpp
+++ b/droppablegroupbox.cpp
@@ -1,0 +1,39 @@
+#include "droppablegroupbox.h"
+#include <QDropEvent>
+#include <QMimeData>
+#include <QDebug>
+
+DroppableGroupBox::DroppableGroupBox(QWidget *parent) :
+    QGroupBox(parent)
+{
+    setAcceptDrops(true);
+}
+
+void DroppableGroupBox::dragEnterEvent(QDragEnterEvent *event)
+{
+    if (event->mimeData() && event->mimeData()->hasUrls())
+    {
+        QList<QUrl> urls = event->mimeData()->urls();
+        if (urls.count() == 1 &&
+            urls[0].isLocalFile() &&
+            QFile::exists(urls[0].toLocalFile()))
+        {
+            event->accept();
+        }
+    }
+}
+
+void DroppableGroupBox::dropEvent(QDropEvent *event)
+{
+    if (event->mimeData() && event->mimeData()->hasUrls())
+    {
+        QList<QUrl> urls = event->mimeData()->urls();
+        if (urls.count() == 1 &&
+            urls[0].isLocalFile() &&
+            QFile::exists(urls[0].toLocalFile()))
+        {
+            event->accept();
+            emit fileDropped(urls[0].toLocalFile());
+        }
+    }
+}

--- a/droppablegroupbox.h
+++ b/droppablegroupbox.h
@@ -1,0 +1,20 @@
+#ifndef DROPPABLEGROUPBOX_H
+#define DROPPABLEGROUPBOX_H
+
+#include <QGroupBox>
+
+class DroppableGroupBox : public QGroupBox
+{
+    Q_OBJECT
+public:
+    DroppableGroupBox(QWidget *parent = 0);
+
+protected:
+    void dragEnterEvent(QDragEnterEvent *event);
+    void dropEvent(QDropEvent *event);
+
+signals:
+    void fileDropped(QString path);
+};
+
+#endif // DROPPABLEGROUPBOX_H

--- a/main.cpp
+++ b/main.cpp
@@ -25,6 +25,6 @@ int main(int argc, char *argv[])
     QApplication a(argc, argv);
     MainWindow w;
     w.show();
-    
+
     return a.exec();
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -303,7 +303,7 @@ void MainWindow::on_writeToSIMMButton_clicked()
         }
         else
         {
-            p->writeToSIMM(writeFile, 0, howMuchToErase);
+            p->writeToSIMM(writeFile, 0, qMin(howMuchToErase, p->SIMMCapacity()));
         }
         qDebug() << "Writing to SIMM...";
     }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -343,6 +343,18 @@ void MainWindow::on_chosenReadFile_textEdited(const QString &newText)
     }
 }
 
+void MainWindow::on_writeGroupBox_fileDropped(const QString &filePath)
+{
+    ui->chosenWriteFile->setText(filePath);
+    on_chosenWriteFile_textEdited(filePath);
+}
+
+void MainWindow::on_readGroupBox_fileDropped(const QString &filePath)
+{
+    ui->chosenReadFile->setText(filePath);
+    on_chosenReadFile_textEdited(filePath);
+}
+
 void MainWindow::programmerWriteStatusChanged(WriteStatus newStatus)
 {
     switch (newStatus)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -34,7 +34,7 @@ static Programmer *p;
 #define selectedEraseSizeKey    "selectedEraseSize"
 
 struct SIMMDesc {
-    uint32_t index;
+    uint32_t saveValue;
     const char *text;
     uint32_t size;
     uint32_t chipType;
@@ -46,6 +46,7 @@ SIMMDesc simmTable[] ={
     {2, "512KB (4x 1Mb PLCC)",   512, SIMM_PLCC_x8 },
     {3, "1MB (4x 2Mb PLCC)",    1024, SIMM_PLCC_x8 },
     {4, "2MB (4x 4Mb PLCC)",    2048, SIMM_PLCC_x8 },
+    {8, "2MB (2x 8Mb TSOP)",    2048, SIMM_TSOP_x16},
     {5, "4MB (2x 16Mb TSOP)",   4096, SIMM_TSOP_x16},
     {6, "8MB (4x 16Mb TSOP)",   8192, SIMM_TSOP_x8 },
     {7, "8MB (2x 32Mb TSOP)",   8192, SIMM_TSOP_x16},
@@ -75,7 +76,7 @@ MainWindow::MainWindow(QWidget *parent) :
     // Fill in the list of SIMM chip capacities (programmer can support anywhere up to 8 MB of space)
     for (size_t i = 0; i < sizeof(simmTable)/sizeof(simmTable[0]); i++)
     {
-        ui->simmCapacityBox->addItem(simmTable[i].text, QVariant(simmTable[i].index));
+        ui->simmCapacityBox->addItem(simmTable[i].text, QVariant(simmTable[i].saveValue));
     }
 
     // Select 2 MB by default (it's what most people will want), or load last-used setting
@@ -953,14 +954,14 @@ void MainWindow::resetAndShowStatusPage()
 
 void MainWindow::on_simmCapacityBox_currentIndexChanged(int index)
 {
-    uint32_t idx = static_cast<uint32_t>(ui->simmCapacityBox->itemData(index).toUInt());
-    p->setSIMMType(simmTable[idx].size*1024, simmTable[idx].chipType);
+    p->setSIMMType(simmTable[index].size*1024, simmTable[index].chipType);
     QSettings settings;
     if (!initializing)
     {
         // If we're not initializing (it gets called while we're initializing),
         // go ahead and save this as the new default.
-        settings.setValue(selectedCapacityKey, idx);
+        uint32_t saveValue = static_cast<uint32_t>(ui->simmCapacityBox->itemData(index).toUInt());
+        settings.setValue(selectedCapacityKey, saveValue);
     }
 }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -124,6 +124,8 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->howMuchToWriteBox->addItem("Only erase/write first 1 MB", QVariant(1024*1024));
     ui->howMuchToWriteBox->addItem("Only erase/write first 1.5 MB", QVariant(3*512*1024));
     ui->howMuchToWriteBox->addItem("Only erase/write first 2 MB", QVariant(2*1024*1024));
+    ui->howMuchToWriteBox->addItem("Only erase/write first 4 MB", QVariant(4*1024*1024));
+    ui->howMuchToWriteBox->addItem("Only erase/write first 8 MB", QVariant(8*1024*1024));
 
     // Select "erase entire SIMM" by default, or load last-used setting
     QVariant selectedEraseSize = settings.value(selectedEraseSizeKey, QVariant(0));

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -33,22 +33,22 @@ static Programmer *p;
 #define verifyWhileWritingKey   "verifyWhileWriting"
 #define selectedEraseSizeKey    "selectedEraseSize"
 
-struct simmdesc {
-  uint32_t idx;
-  const char *text;
-  uint32_t size;
-  uint32_t chip_type;
+struct SIMMDesc {
+    uint32_t index;
+    const char *text;
+    uint32_t size;
+    uint32_t chipType;
 };
 
-simmdesc simmtable[] = {
-  { 0, "128KB (4x 256Kb PLCC)", 128, SIMM_PLCC_x8  },
-  { 1, "256KB (4x 512Kb PLCC)", 256, SIMM_PLCC_x8  },
-  { 2, "512KB (4x 1Mb PLCC)",   512, SIMM_PLCC_x8  },
-  { 3, "1MB (4x 2Mb PLCC)",    1024, SIMM_PLCC_x8  },
-  { 4, "2MB (4x 4Mb PLCC)",    2048, SIMM_PLCC_x8  },
-  { 5, "4MB (2x 16Mb TSOP)",   4096, SIMM_TSOP_x16 },
-  { 6, "8MB (4x 16Mb TSOP)",   8192, SIMM_TSOP_x8  },
-  { 7, "8MB (2x 32Mb TSOP)",   8192, SIMM_TSOP_x16 },
+SIMMDesc simmTable[] ={
+    {0, "128KB (4x 256Kb PLCC)", 128, SIMM_PLCC_x8 },
+    {1, "256KB (4x 512Kb PLCC)", 256, SIMM_PLCC_x8 },
+    {2, "512KB (4x 1Mb PLCC)",   512, SIMM_PLCC_x8 },
+    {3, "1MB (4x 2Mb PLCC)",    1024, SIMM_PLCC_x8 },
+    {4, "2MB (4x 4Mb PLCC)",    2048, SIMM_PLCC_x8 },
+    {5, "4MB (2x 16Mb TSOP)",   4096, SIMM_TSOP_x16},
+    {6, "8MB (4x 16Mb TSOP)",   8192, SIMM_TSOP_x8 },
+    {7, "8MB (2x 32Mb TSOP)",   8192, SIMM_TSOP_x16},
 };
 
 MainWindow::MainWindow(QWidget *parent) :
@@ -73,8 +73,9 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->actionUpdate_firmware->setEnabled(false);
 
     // Fill in the list of SIMM chip capacities (programmer can support anywhere up to 8 MB of space)
-    for(size_t i=0; i<sizeof(simmtable)/sizeof(simmdesc); i++) {
-      ui->simmCapacityBox->addItem(simmtable[i].text, QVariant(simmtable[i].idx));
+    for (size_t i = 0; i < sizeof(simmTable)/sizeof(simmTable[0]); i++)
+    {
+        ui->simmCapacityBox->addItem(simmTable[i].text, QVariant(simmTable[i].index));
     }
 
     // Select 2 MB by default (it's what most people will want), or load last-used setting
@@ -953,7 +954,7 @@ void MainWindow::resetAndShowStatusPage()
 void MainWindow::on_simmCapacityBox_currentIndexChanged(int index)
 {
     uint32_t idx = static_cast<uint32_t>(ui->simmCapacityBox->itemData(index).toUInt());
-    p->setSIMMType(simmtable[idx].size*1024, simmtable[idx].chip_type);
+    p->setSIMMType(simmTable[idx].size*1024, simmTable[idx].chipType);
     QSettings settings;
     if (!initializing)
     {

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -46,6 +46,9 @@ private slots:
     void on_chosenWriteFile_textEdited(const QString &newText);
     void on_chosenReadFile_textEdited(const QString &newText);
 
+    void on_writeGroupBox_fileDropped(const QString &filePath);
+    void on_readGroupBox_fileDropped(const QString &filePath);
+
     void programmerWriteStatusChanged(WriteStatus newStatus);
     void programmerWriteTotalLengthChanged(uint32_t totalLen);
     void programmerWriteCompletionLengthChanged(uint32_t len);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -31,11 +31,11 @@ class MainWindow;
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
-    
+
 public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
-    
+
 private slots:
     void on_selectWriteFileButton_clicked();
     void on_selectReadFileButton_clicked();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -56,7 +56,7 @@
          </layout>
         </item>
         <item>
-         <widget class="QGroupBox" name="writeGroupBox">
+         <widget class="DroppableGroupBox" name="writeGroupBox">
           <property name="title">
            <string>Write file to SIMM</string>
           </property>
@@ -113,7 +113,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="readGroupBox">
+         <widget class="DroppableGroupBox" name="readGroupBox">
           <property name="title">
            <string>Read from SIMM to file</string>
           </property>
@@ -624,6 +624,14 @@
   </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>DroppableGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>droppablegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/programmer.cpp
+++ b/programmer.cpp
@@ -21,6 +21,7 @@
 #include <QDebug>
 #include <QWaitCondition>
 #include <QMutex>
+#include <QTimer>
 
 typedef enum ProgrammerCommandState
 {
@@ -282,7 +283,7 @@ void Programmer::writeToSIMM(QIODevice *device, uint8_t chipsMask)
 
         // Based on the SIMM type, tell the programmer board.
         uint8_t setLayoutCommand;
-	if(SIMMChip()==SIMM_TSOP_x8)
+        if (SIMMChip() == SIMM_TSOP_x8)
         {
             setLayoutCommand = SetSIMMLayout_AddressShifted;
         }
@@ -325,7 +326,7 @@ void Programmer::writeToSIMM(QIODevice *device, uint32_t startOffset, uint32_t l
 
         // Based on the SIMM type, tell the programmer board.
         uint8_t setLayoutCommand;
-	if (SIMMChip() == SIMM_TSOP_x8)
+        if (SIMMChip() == SIMM_TSOP_x8)
         {
             setLayoutCommand = SetSIMMLayout_AddressShifted;
         }
@@ -905,7 +906,7 @@ void Programmer::handleChar(uint8_t c)
 
     // READ SIMM STATE HANDLERS
 
-    // Expecting reply after we told the programmer to start reading       
+    // Expecting reply after we told the programmer to start reading
     case ReadSIMMWaitingStartReply:
     case ReadSIMMWaitingStartOffsetReply:
         switch (c)
@@ -1160,7 +1161,7 @@ void Programmer::handleChar(uint8_t c)
             // If we got an error reply, we MAY still be OK unless we were
             // requesting the large SIMM type, in which case the firmware
             // doesn't support the large SIMM type so the user needs to know.
-	    if (SIMMChip() != SIMM_PLCC_x8)
+            if (SIMMChip() != SIMM_PLCC_x8)
             {
                 // Uh oh -- this is an old firmware that doesn't support a big
                 // SIMM. Let the caller know that the programmer board needs a
@@ -1484,7 +1485,6 @@ void Programmer::startBootloaderCommand(uint8_t commandByte, uint32_t newState)
     sendByte(GetBootloaderState);
 }
 
-#include <QTimer>
 void Programmer::portDiscovered(const QextPortInfo &info)
 {
     if ((foundState == ProgrammerBoardNotFound) &&
@@ -1549,7 +1549,7 @@ void Programmer::portRemoved(const QextPortInfo &info)
     const bool matchingPortName = programmerBoardPortName != "" && info.portName == programmerBoardPortName;
     if ((matchingVIDPID || matchingPortName) &&
         (foundState == ProgrammerBoardFound))
-    {       
+    {
         programmerBoardPortName = "";
         foundState = ProgrammerBoardNotFound;
 

--- a/programmer.cpp
+++ b/programmer.cpp
@@ -1396,6 +1396,10 @@ QString Programmer::electricalTestPinName(uint8_t index)
     {
         return "GND";
     }
+    else if (index == VCC_FAIL_INDEX)
+    {
+        return "+5V";
+    }
     else
     {
         return "?";

--- a/programmer.h
+++ b/programmer.h
@@ -104,6 +104,7 @@ typedef enum VerificationOption
 
 // Electrical test indexes
 #define GROUND_FAIL_INDEX					0xFF
+#define VCC_FAIL_INDEX						0xFE
 
 #define FIRST_ADDRESS_LINE_FAIL_INDEX		0
 #define LAST_ADDRESS_LINE_FAIL_INDEX		(FIRST_ADDRESS_LINE_FAIL_INDEX + 20)


### PR DESCRIPTION
- Prepare for the ability to detect shorts to +5V
- Add an option for 2-chip 2 MB SIMMs (CayMac)
- Add ability for programming first 4 or 8 MB (useful for Garrett's Workshop huge SIMM). Note this also requires firmware 1.4.1 or newer.
- Add ability to drag and drop files to the write and read section, suggested by JDW.