### PR TITLE
Windows 7 fixes

### DIFF
--- a/programmer.cpp
+++ b/programmer.cpp
@@ -1157,6 +1157,7 @@ void Programmer::handleChar(uint8_t c)
             qDebug() << "We're in the bootloader, so sending an \"enter programmer\" request.";
             emit startStatusChanged(ProgrammerInitializing);
             sendByte(EnterProgrammer);
+            serialPort->flush();
             closePort();
 
             // Now wait for it to reconnect
@@ -1201,6 +1202,7 @@ void Programmer::handleChar(uint8_t c)
             qDebug() << "We're in the programmer, so sending an \"enter bootloader\" request.";
             emit startStatusChanged(ProgrammerInitializing);
             sendByte(EnterBootloader);
+            serialPort->flush();
             closePort();
 
             // Now wait for it to reconnect


### PR DESCRIPTION
Fix issues discussed on 68kmla here:
https://68kmla.org/bb/index.php?threads/rom-simm-programmer.44523/#post-511827

There were actually two problems.

1. Newer versions of QextSerialPort enumerate over `GUID_DEVINTERFACE_COMPORT` devices, but that approach doesn't work on Windows 7. Instead, fall back to the older behavior that loops over a few different device classes.
2. In some cases, commands weren't being sent out quickly enough when the port was closed. I suspect this is again a Windows 7-only thing because I never experienced any issues in Windows 10.