### PR TITLE
Quadra rom support

### DIFF
--- a/createblankdiskdialog.cpp
+++ b/createblankdiskdialog.cpp
@@ -42,6 +42,16 @@ CreateBlankDiskDialog::CreateBlankDiskDialog(QWidget *parent) :
     ui->sizeBox->addItem("3.5 MB (for 4 MB SIMM, uncompressed)", 3670016);
     ui->sizeBox->addItem("7.5 MB (for 8 MB SIMM, uncompressed)", 7864320);
 
+    // And finally, for Quadra SIMMs:
+    ui->sizeBox->addItem("Uncompressed, for 1 MB Quadra ROMs:");
+    if (!setComboBoxItemEnabled(ui->sizeBox->count() - 1, false))
+    {
+        ui->sizeBox->removeItem(ui->sizeBox->count() - 1);
+    }
+    ui->sizeBox->addItem("1.0 MB (for 2 MB SIMM with Quadra ROM)", 1048576);
+    ui->sizeBox->addItem("3.0 MB (for 4 MB SIMM with Quadra ROM)", 3145728);
+    ui->sizeBox->addItem("7.0 MB (for 8 MB SIMM with Quadra ROM)", 7340032);
+
     // Finally, a section for custom items
     ui->sizeBox->addItem("Custom:");
     if (!setComboBoxItemEnabled(ui->sizeBox->count() - 1, false))

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -147,6 +147,7 @@ private:
         BaseROMbbraun8MB,
         BaseROMBMOW,
         BaseROMGarrettsWorkshop,
+        BaseROMbbraunInQuadra,
     };
 
     void resetAndShowStatusPage();
@@ -160,6 +161,7 @@ private:
     bool checkBaseROMValidity(QString &errorText);
     bool checkBaseROMCompressionSupport();
     KnownBaseROM identifyBaseROM(QByteArray const *baseROMToCheck = NULL);
+    int offsetToQuadraROMDiskSize(QByteArray const &baseROM);
     bool checkDiskImageValidity(QString &errorText, bool &alreadyCompressed);
     bool isCompressedDiskImage(QByteArray const &image);
     void compressImageInBackground(QByteArray uncompressedImage, bool blockUntilCompletion);


### PR DESCRIPTION
Add support for larger ROM files. Remove the restriction that they have to be 512 KB.

Add new blank image sizes appropriate for Quadra ROMs too. Note that currently the Quadra ROMs don't work with compression. I can add future detection for other patterns in the future if needed.